### PR TITLE
Change typedef for MinimumFunction

### DIFF
--- a/hector_stability_metrics/include/hector_stability_metrics/math/minimum.h
+++ b/hector_stability_metrics/include/hector_stability_metrics/math/minimum.h
@@ -13,7 +13,7 @@ namespace hector_stability_metrics
 namespace math
 {
 template <typename Scalar>
-using MinimumFunction = Scalar(const std::vector<Scalar>&);
+using MinimumFunction = std::function<Scalar(const std::vector<Scalar>&)>;
 
 template <typename Scalar>
 Scalar standardMinimum(const std::vector<Scalar>& values);

--- a/hector_stability_metrics/include/hector_stability_metrics/math/types.h
+++ b/hector_stability_metrics/include/hector_stability_metrics/math/types.h
@@ -4,51 +4,51 @@
 #ifndef HECTOR_STABILITY_METRICS_TYPES_H
 #define HECTOR_STABILITY_METRICS_TYPES_H
 
-#include <Eigen/Core>
-#include <Eigen/StdVector>
+#include <eigen3/Eigen/Core>
+#include <eigen3/Eigen/StdVector>
 #include <vector>
 
 namespace hector_stability_metrics
 {
 namespace math
 {
-template<typename Scalar>
+template <typename Scalar>
 using Matrix3 = Eigen::Matrix<Scalar, 3, 3>;
 using Matrix3f = Matrix3<float>;
 using Matrix3d = Matrix3<double>;
 
-template<typename Scalar>
+template <typename Scalar>
 using Vector2 = Eigen::Matrix<Scalar, 2, 1>;
 using Vector2f = Vector2<float>;
 using Vector2d = Vector2<double>;
-template<typename Scalar>
+template <typename Scalar>
 using Vector2List = std::vector<Vector2<Scalar>, Eigen::aligned_allocator<Vector2<Scalar> > >;
 using Vector2fList = Vector2List<float>;
 using Vector2dList = Vector2List<double>;
 
-template<typename Scalar>
+template <typename Scalar>
 using Vector3 = Eigen::Matrix<Scalar, 3, 1>;
 using Vector3f = Vector3<float>;
 using Vector3d = Vector3<double>;
-template<typename Scalar>
+template <typename Scalar>
 using Vector3List = std::vector<Vector3<Scalar> >;
 using Vector3fList = Vector3List<float>;
 using Vector3dList = Vector3List<double>;
 
-template<typename Scalar>
+template <typename Scalar>
 using VectorX = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
 using VectorXf = VectorX<float>;
 using VectorXd = VectorX<double>;
-template<typename Scalar>
+template <typename Scalar>
 using VectorXList = std::vector<VectorX<Scalar> >;
 using VectorXfList = VectorXList<float>;
 using VectorXdList = VectorXList<double>;
 
-template<typename Scalar>
+template <typename Scalar>
 using Isometry3 = Eigen::Transform<Scalar, 3, Eigen::Isometry>;
 using Isometry3f = Isometry3<float>;
 using Isometry3d = Isometry3<double>;
-}
+}  // namespace math
 }  // namespace hector_stability_metrics
 
 #endif  // HECTOR_STABILITY_METRICS_TYPES_H

--- a/hector_stability_metrics/include/hector_stability_metrics/metrics/force_angle_stability_measure.h
+++ b/hector_stability_metrics/include/hector_stability_metrics/metrics/force_angle_stability_measure.h
@@ -7,7 +7,7 @@
 #include "hector_stability_metrics/math/support_polygon.h"
 #include "hector_stability_metrics/metrics/common.h"
 
-#include <Eigen/Geometry>
+#include <eigen3/Eigen/Geometry>
 
 namespace hector_stability_metrics
 {
@@ -29,100 +29,76 @@ namespace non_differentiable
  *
  * @{
  */
-template<typename Scalar>
-void computeForceAngleStabilityMeasure( const math::Vector3List<Scalar> &support_polygon,
-                                        std::vector<Scalar> &edge_stabilities,
-                                        const math::Vector3<Scalar> &center_of_mass,
-                                        const math::Vector3<Scalar> &external_force,
-                                        Scalar normalization_factor = Scalar( 1 ));
+template <typename Scalar>
+void computeForceAngleStabilityMeasure(const math::Vector3List<Scalar>& support_polygon, std::vector<Scalar>& edge_stabilities, const math::Vector3<Scalar>& center_of_mass,
+                                       const math::Vector3<Scalar>& external_force, Scalar normalization_factor = Scalar(1));
 
 //! @return The minimum stability value of all edges.
-template<typename Scalar>
-Scalar computeForceAngleStabilityMeasureValue( const math::Vector3List<Scalar> &support_polygon,
-                                               std::vector<Scalar> &edge_stabilities,
-                                               const math::Vector3<Scalar> &center_of_mass,
-                                               const math::Vector3<Scalar> &external_force,
-                                               Scalar normalization_factor = Scalar( 1 ));
+template <typename Scalar>
+Scalar computeForceAngleStabilityMeasureValue(const math::Vector3List<Scalar>& support_polygon, std::vector<Scalar>& edge_stabilities, const math::Vector3<Scalar>& center_of_mass,
+                                              const math::Vector3<Scalar>& external_force, Scalar normalization_factor = Scalar(1));
 
 //! @return The index of the minimum stability value of all edges.
-template<typename Scalar>
-size_t computeForceAngleStabilityMeasureLeastStableEdgeIndex( const math::Vector3List<Scalar> &support_polygon,
-                                                              std::vector<Scalar> &edge_stabilities,
-                                                              const math::Vector3<Scalar> &center_of_mass,
-                                                              const math::Vector3<Scalar> &external_force,
-                                                              Scalar normalization_factor = Scalar( 1 ));
+template <typename Scalar>
+size_t computeForceAngleStabilityMeasureLeastStableEdgeIndex(const math::Vector3List<Scalar>& support_polygon, std::vector<Scalar>& edge_stabilities,
+                                                             const math::Vector3<Scalar>& center_of_mass, const math::Vector3<Scalar>& external_force,
+                                                             Scalar normalization_factor = Scalar(1));
 /*! @} */
 
 namespace impl
 {
-
-template<typename Scalar, typename MinimumType = Scalar, typename MinimumSelector = math::MinimumSelector<Scalar, MinimumType>>
-typename MinimumSelector::ReturnType computeForceAngleStabilityMeasure( const math::Vector3List<Scalar> &support_polygon,
-                                                                        std::vector<Scalar> &edge_stabilities,
-                                                                        const math::Vector3<Scalar> &center_of_mass,
-                                                                        const math::Vector3<Scalar> &external_force,
-                                                                        Scalar normalization_factor = Scalar( 1 ))
+template <typename Scalar, typename MinimumType = Scalar, typename MinimumSelector = math::MinimumSelector<Scalar, MinimumType>>
+typename MinimumSelector::ReturnType computeForceAngleStabilityMeasure(const math::Vector3List<Scalar>& support_polygon, std::vector<Scalar>& edge_stabilities,
+                                                                       const math::Vector3<Scalar>& center_of_mass, const math::Vector3<Scalar>& external_force,
+                                                                       Scalar normalization_factor = Scalar(1))
 {
   const size_t number_of_edges = support_polygon.size();
-  edge_stabilities.resize( number_of_edges );
+  edge_stabilities.resize(number_of_edges);
   MinimumSelector minimum_selector;
 
-  for ( size_t i = 0; i < number_of_edges; ++i )
+  for (size_t i = 0; i < number_of_edges; ++i)
   {
-    const math::Vector3<Scalar> &axis = (math::getSupportPolygonEdge( support_polygon, i )).normalized();
-    const math::Matrix3<Scalar> &projection = math::Matrix3<Scalar>::Identity() - axis * axis.transpose();
+    const math::Vector3<Scalar>& axis = (math::getSupportPolygonEdge(support_polygon, i)).normalized();
+    const math::Matrix3<Scalar>& projection = math::Matrix3<Scalar>::Identity() - axis * axis.transpose();
     math::Vector3<Scalar> axis_normal = projection * (support_polygon[i] - center_of_mass);
     // Since the mass normally doesn't change, we omit it
-    const math::Vector3<Scalar> &force_component = projection * external_force;
+    const math::Vector3<Scalar>& force_component = projection * external_force;
     const Scalar force_component_norm = force_component.norm();
-    const math::Vector3<Scalar> &force_component_normalized = force_component / force_component_norm;
-    const Scalar distance = (-axis_normal +
-                             axis_normal.dot( force_component_normalized ) * force_component_normalized).norm();
+    const math::Vector3<Scalar>& force_component_normalized = force_component / force_component_norm;
+    const Scalar distance = (-axis_normal + axis_normal.dot(force_component_normalized) * force_component_normalized).norm();
     axis_normal.normalize();
-    const Scalar sigma = axis_normal.cross( force_component_normalized ).dot( axis ) < 0 ? 1 : -1;
-    const Scalar theta = sigma * std::acos( force_component_normalized.dot( axis_normal ));
+    const Scalar sigma = axis_normal.cross(force_component_normalized).dot(axis) < 0 ? 1 : -1;
+    const Scalar theta = sigma * std::acos(force_component_normalized.dot(axis_normal));
     const Scalar beta = theta * distance * force_component_norm;
     const Scalar value = beta * normalization_factor;
     edge_stabilities[i] = value;
-    minimum_selector.updateMinimum( i, value );
+    minimum_selector.updateMinimum(i, value);
   }
   return minimum_selector.getMinimum();
 }
+}  // namespace impl
+
+template <typename Scalar>
+void computeForceAngleStabilityMeasure(const math::Vector3List<Scalar>& support_polygon, std::vector<Scalar>& edge_stabilities, const math::Vector3<Scalar>& center_of_mass,
+                                       const math::Vector3<Scalar>& external_force, Scalar normalization_factor)
+{
+  impl::computeForceAngleStabilityMeasure<Scalar, void>(support_polygon, edge_stabilities, center_of_mass, external_force, normalization_factor);
 }
 
-template<typename Scalar>
-void computeForceAngleStabilityMeasure( const math::Vector3List<Scalar> &support_polygon,
-                                        std::vector<Scalar> &edge_stabilities,
-                                        const math::Vector3<Scalar> &center_of_mass,
-                                        const math::Vector3<Scalar> &external_force,
-                                        Scalar normalization_factor )
+template <typename Scalar>
+Scalar computeForceAngleStabilityMeasureValue(const math::Vector3List<Scalar>& support_polygon, std::vector<Scalar>& edge_stabilities, const math::Vector3<Scalar>& center_of_mass,
+                                              const math::Vector3<Scalar>& external_force, Scalar normalization_factor)
 {
-  impl::computeForceAngleStabilityMeasure<Scalar, void>( support_polygon, edge_stabilities, center_of_mass,
-                                                         external_force, normalization_factor );
+  return impl::computeForceAngleStabilityMeasure<Scalar>(support_polygon, edge_stabilities, center_of_mass, external_force, normalization_factor);
 }
 
-template<typename Scalar>
-Scalar computeForceAngleStabilityMeasureValue( const math::Vector3List<Scalar> &support_polygon,
-                                               std::vector<Scalar> &edge_stabilities,
-                                               const math::Vector3<Scalar> &center_of_mass,
-                                               const math::Vector3<Scalar> &external_force,
-                                               Scalar normalization_factor )
+template <typename Scalar>
+size_t computeForceAngleStabilityMeasureLeastStableEdgeIndex(const math::Vector3List<Scalar>& support_polygon, std::vector<Scalar>& edge_stabilities,
+                                                             const math::Vector3<Scalar>& center_of_mass, const math::Vector3<Scalar>& external_force, Scalar normalization_factor)
 {
-  return impl::computeForceAngleStabilityMeasure<Scalar>( support_polygon, edge_stabilities,
-                                                          center_of_mass, external_force, normalization_factor );
+  return impl::computeForceAngleStabilityMeasure<Scalar, size_t>(support_polygon, edge_stabilities, center_of_mass, external_force, normalization_factor);
 }
-
-template<typename Scalar>
-size_t computeForceAngleStabilityMeasureLeastStableEdgeIndex( const math::Vector3List<Scalar> &support_polygon,
-                                                              std::vector<Scalar> &edge_stabilities,
-                                                              const math::Vector3<Scalar> &center_of_mass,
-                                                              const math::Vector3<Scalar> &external_force,
-                                                              Scalar normalization_factor )
-{
-  return impl::computeForceAngleStabilityMeasure<Scalar, size_t>( support_polygon, edge_stabilities, center_of_mass,
-                                                                  external_force, normalization_factor );
-}
-}  // non_differentiable
+}  // namespace non_differentiable
 }  // namespace hector_stability_metrics
 
 #endif  // HECTOR_STABILITY_METRICS_FORCE_ANGLE_STABILITY_MEASURE_H

--- a/hector_stability_metrics/test/eigen_tests.h
+++ b/hector_stability_metrics/test/eigen_tests.h
@@ -4,47 +4,43 @@
 #ifndef HECTOR_EIGEN_TESTS_H
 #define HECTOR_EIGEN_TESTS_H
 
-#include <Eigen/Dense>
-#include <Eigen/Geometry>
+#include <eigen3/Eigen/Dense>
+#include <eigen3/Eigen/Geometry>
 #include <gtest/gtest.h>
 
-#define EIGEN_MATRIX_EQUAL( A, B ) DenseBaseEqual(A, #A, B, #B)
-#define EIGEN_ARRAY_EQUAL( A, B ) DenseBaseEqual(A, #A, B, #B)
-#define EIGEN_QUATERNIONS_EQUAL( A, B ) QuaternionBaseEqual(A, #A, B, #B)
-#define EIGEN_VECTOR_EQUAL( A, B ) DenseBaseEqual(A, #A, B, #B)
+#define EIGEN_MATRIX_EQUAL(A, B) DenseBaseEqual(A, #A, B, #B)
+#define EIGEN_ARRAY_EQUAL(A, B) DenseBaseEqual(A, #A, B, #B)
+#define EIGEN_QUATERNIONS_EQUAL(A, B) QuaternionBaseEqual(A, #A, B, #B)
+#define EIGEN_VECTOR_EQUAL(A, B) DenseBaseEqual(A, #A, B, #B)
 
-#define EIGEN_MATRIX_NEAR( A, B, precision ) DenseBaseNear(A, #A, B, #B, precision)
-#define EIGEN_ARRAY_NEAR( A, B, precision ) DenseBaseNear(A, #A, B, #B, precision)
-#define EIGEN_QUATERNIONS_NEAR( A, B, precision ) QuaternionBaseNear(A, #A, B, #B, precision)
-#define EIGEN_VECTOR_NEAR( A, B, precision ) DenseBaseNear(A, #A, B, #B, precision)
+#define EIGEN_MATRIX_NEAR(A, B, precision) DenseBaseNear(A, #A, B, #B, precision)
+#define EIGEN_ARRAY_NEAR(A, B, precision) DenseBaseNear(A, #A, B, #B, precision)
+#define EIGEN_QUATERNIONS_NEAR(A, B, precision) QuaternionBaseNear(A, #A, B, #B, precision)
+#define EIGEN_VECTOR_NEAR(A, B, precision) DenseBaseNear(A, #A, B, #B, precision)
 
 #define EIGEN_MATRIX_SAME_FINITE(A, B) DenseBaseSameFinite(A, #A, B, #B)
 #define EIGEN_ARRAY_SAME_FINITE(A, B) DenseBaseSameFinite(A, #A, B, #B)
 
-template<typename DerivedA, typename DerivedB>
-::testing::AssertionResult DenseBaseEqual( const Eigen::DenseBase<DerivedA> &lh, const std::string &lh_name,
-                                           const Eigen::DenseBase<DerivedB> &rh, const std::string &rh_name )
+template <typename DerivedA, typename DerivedB>
+::testing::AssertionResult DenseBaseEqual(const Eigen::DenseBase<DerivedA>& lh, const std::string& lh_name, const Eigen::DenseBase<DerivedB>& rh, const std::string& rh_name)
 {
-  if ( lh.rows() != rh.rows() || lh.cols() != rh.cols())
+  if (lh.rows() != rh.rows() || lh.cols() != rh.cols())
   {
-    return ::testing::AssertionFailure()
-      << "Matrix sizes do not match!"
-      << " (" << lh_name << ") " << lh.rows() << "x" << lh.cols()
-      << " vs "
-      << rh.rows() << "x" << rh.cols() << " (" << rh_name << ").";
+    return ::testing::AssertionFailure() << "Matrix sizes do not match!"
+                                         << " (" << lh_name << ") " << lh.rows() << "x" << lh.cols() << " vs " << rh.rows() << "x" << rh.cols() << " (" << rh_name << ").";
   }
-  for ( Eigen::Index col = 0; col < lh.cols(); ++col )
+  for (Eigen::Index col = 0; col < lh.cols(); ++col)
   {
-    for ( Eigen::Index row = 0; row < lh.rows(); ++row )
+    for (Eigen::Index row = 0; row < lh.rows(); ++row)
     {
-      if ( lh( row, col ) == rh( row, col )) continue;
-      if ( std::isnan( lh( row, col )) && std::isnan( rh( row, col ))) continue;
+      if (lh(row, col) == rh(row, col))
+        continue;
+      if (std::isnan(lh(row, col)) && std::isnan(rh(row, col)))
+        continue;
 
       return ::testing::AssertionFailure() << "Matrices not equal!" << std::endl
-                                           << lh_name << " at " << row << ", " << col << ": " << lh( row, col )
-                                           << std::endl
-                                           << rh_name << " at " << row << ", " << col << ": " << rh( row, col )
-                                           << std::endl
+                                           << lh_name << " at " << row << ", " << col << ": " << lh(row, col) << std::endl
+                                           << rh_name << " at " << row << ", " << col << ": " << rh(row, col) << std::endl
                                            << lh_name << ":" << std::endl
                                            << lh << std::endl
                                            << rh_name << ":" << std::endl
@@ -54,29 +50,24 @@ template<typename DerivedA, typename DerivedB>
   return ::testing::AssertionSuccess();
 }
 
-template<typename DerivedA, typename DerivedB>
-::testing::AssertionResult DenseBaseSameFinite( const Eigen::DenseBase<DerivedA> &lh, const std::string &lh_name,
-                                                const Eigen::DenseBase<DerivedB> &rh, const std::string &rh_name )
+template <typename DerivedA, typename DerivedB>
+::testing::AssertionResult DenseBaseSameFinite(const Eigen::DenseBase<DerivedA>& lh, const std::string& lh_name, const Eigen::DenseBase<DerivedB>& rh, const std::string& rh_name)
 {
-  if ( lh.rows() != rh.rows() || lh.cols() != rh.cols())
+  if (lh.rows() != rh.rows() || lh.cols() != rh.cols())
   {
-    return ::testing::AssertionFailure()
-      << "Matrix sizes do not match!"
-      << " (" << lh_name << ") " << lh.rows() << "x" << lh.cols()
-      << " vs "
-      << rh.rows() << "x" << rh.cols() << " (" << rh_name << ").";
+    return ::testing::AssertionFailure() << "Matrix sizes do not match!"
+                                         << " (" << lh_name << ") " << lh.rows() << "x" << lh.cols() << " vs " << rh.rows() << "x" << rh.cols() << " (" << rh_name << ").";
   }
-  for ( Eigen::Index col = 0; col < lh.cols(); ++col )
+  for (Eigen::Index col = 0; col < lh.cols(); ++col)
   {
-    for ( Eigen::Index row = 0; row < lh.rows(); ++row )
+    for (Eigen::Index row = 0; row < lh.rows(); ++row)
     {
-      if ( std::isfinite( lh( row, col )) == std::isfinite( rh( row, col ))) continue;
+      if (std::isfinite(lh(row, col)) == std::isfinite(rh(row, col)))
+        continue;
 
       return ::testing::AssertionFailure() << "Matrices finite fields not equal!" << std::endl
-                                           << lh_name << " at " << row << ", " << col << ": " << lh( row, col )
-                                           << std::endl
-                                           << rh_name << " at " << row << ", " << col << ": " << rh( row, col )
-                                           << std::endl
+                                           << lh_name << " at " << row << ", " << col << ": " << lh(row, col) << std::endl
+                                           << rh_name << " at " << row << ", " << col << ": " << rh(row, col) << std::endl
                                            << lh_name << ":" << std::endl
                                            << lh << std::endl
                                            << rh_name << ":" << std::endl
@@ -86,33 +77,28 @@ template<typename DerivedA, typename DerivedB>
   return ::testing::AssertionSuccess();
 }
 
-template<typename DerivedA, typename DerivedB>
-::testing::AssertionResult DenseBaseNear( const Eigen::DenseBase<DerivedA> &lh, const std::string &lh_name,
-                                          const Eigen::DenseBase<DerivedB> &rh, const std::string &rh_name,
-                                          typename std::common_type<typename Eigen::DenseBase<DerivedA>::Scalar, typename Eigen::DenseBase<DerivedB>::Scalar>::type precision )
+template <typename DerivedA, typename DerivedB>
+::testing::AssertionResult DenseBaseNear(const Eigen::DenseBase<DerivedA>& lh, const std::string& lh_name, const Eigen::DenseBase<DerivedB>& rh, const std::string& rh_name,
+                                         typename std::common_type<typename Eigen::DenseBase<DerivedA>::Scalar, typename Eigen::DenseBase<DerivedB>::Scalar>::type precision)
 {
-  if ( lh.rows() != rh.rows() || lh.cols() != rh.cols())
+  if (lh.rows() != rh.rows() || lh.cols() != rh.cols())
   {
-    return ::testing::AssertionFailure()
-      << "Matrix sizes do not match!"
-      << " (" << lh_name << ") " << lh.rows() << "x" << lh.cols()
-      << " vs "
-      << rh.rows() << "x" << rh.cols() << " (" << rh_name << ").";
+    return ::testing::AssertionFailure() << "Matrix sizes do not match!"
+                                         << " (" << lh_name << ") " << lh.rows() << "x" << lh.cols() << " vs " << rh.rows() << "x" << rh.cols() << " (" << rh_name << ").";
   }
-  for ( Eigen::Index col = 0; col < lh.cols(); ++col )
+  for (Eigen::Index col = 0; col < lh.cols(); ++col)
   {
-    for ( Eigen::Index row = 0; row < lh.rows(); ++row )
+    for (Eigen::Index row = 0; row < lh.rows(); ++row)
     {
-      if ( std::abs( lh( row, col ) - rh( row, col )) <= precision ) continue;
-      if ( std::isnan( lh( row, col )) && std::isnan( rh( row, col ))) continue;
+      if (std::abs(lh(row, col) - rh(row, col)) <= precision)
+        continue;
+      if (std::isnan(lh(row, col)) && std::isnan(rh(row, col)))
+        continue;
 
       auto result = ::testing::AssertionFailure() << "Matrices not equal!" << std::endl
-                                                  << lh_name << " at " << row << ", " << col << ": " << lh( row, col )
-                                                  << std::endl
-                                                  << rh_name << " at " << row << ", " << col << ": " << rh( row, col )
-                                                  << std::endl
-                                                  << "Maximum allowed error: " << precision
-                                                  << std::endl
+                                                  << lh_name << " at " << row << ", " << col << ": " << lh(row, col) << std::endl
+                                                  << rh_name << " at " << row << ", " << col << ": " << rh(row, col) << std::endl
+                                                  << "Maximum allowed error: " << precision << std::endl
                                                   << lh_name << ":" << std::endl
                                                   << lh << std::endl
                                                   << rh_name << ":" << std::endl
@@ -123,29 +109,26 @@ template<typename DerivedA, typename DerivedB>
   return ::testing::AssertionSuccess();
 }
 
-template<typename DerivedA, typename DerivedB>
-::testing::AssertionResult QuaternionBaseEqual( const Eigen::QuaternionBase<DerivedA> &lh, const std::string &lh_name,
-                                                const Eigen::QuaternionBase<DerivedB> &rh, const std::string &rh_name )
+template <typename DerivedA, typename DerivedB>
+::testing::AssertionResult QuaternionBaseEqual(const Eigen::QuaternionBase<DerivedA>& lh, const std::string& lh_name, const Eigen::QuaternionBase<DerivedB>& rh,
+                                               const std::string& rh_name)
 {
-  if ( lh.isApprox( rh )) return ::testing::AssertionSuccess();
+  if (lh.isApprox(rh))
+    return ::testing::AssertionSuccess();
   return ::testing::AssertionFailure() << "Quaternions not equal!" << std::endl
-                                       << lh_name << " (w, x, y, z): "
-                                       << lh.w() << ", " << lh.x() << ", " << lh.y() << ", " << lh.z() << std::endl
-                                       << rh_name << " (w, x, y, z): "
-                                       << rh.w() << ", " << rh.x() << ", " << rh.y() << ", " << rh.z();
+                                       << lh_name << " (w, x, y, z): " << lh.w() << ", " << lh.x() << ", " << lh.y() << ", " << lh.z() << std::endl
+                                       << rh_name << " (w, x, y, z): " << rh.w() << ", " << rh.x() << ", " << rh.y() << ", " << rh.z();
 }
 
-template<typename DerivedA, typename DerivedB, typename Scalar>
-::testing::AssertionResult QuaternionBaseNear( const Eigen::QuaternionBase<DerivedA> &lh, const std::string &lh_name,
-                                               const Eigen::QuaternionBase<DerivedB> &rh, const std::string &rh_name,
-                                               Scalar precision )
+template <typename DerivedA, typename DerivedB, typename Scalar>
+::testing::AssertionResult QuaternionBaseNear(const Eigen::QuaternionBase<DerivedA>& lh, const std::string& lh_name, const Eigen::QuaternionBase<DerivedB>& rh,
+                                              const std::string& rh_name, Scalar precision)
 {
-  if ( lh.isApprox( rh, precision )) return ::testing::AssertionSuccess();
+  if (lh.isApprox(rh, precision))
+    return ::testing::AssertionSuccess();
   return ::testing::AssertionFailure() << "Quaternions not equal!" << std::endl
-                                       << lh_name << " (w, x, y, z): "
-                                       << lh.w() << ", " << lh.x() << ", " << lh.y() << ", " << lh.z() << std::endl
-                                       << rh_name << " (w, x, y, z): "
-                                       << rh.w() << ", " << rh.x() << ", " << rh.y() << ", " << rh.z();
+                                       << lh_name << " (w, x, y, z): " << lh.w() << ", " << lh.x() << ", " << lh.y() << ", " << lh.z() << std::endl
+                                       << rh_name << " (w, x, y, z): " << rh.w() << ", " << rh.x() << ", " << rh.y() << ", " << rh.z();
 }
 
-#endif //HECTOR_EIGEN_TESTS_H
+#endif  // HECTOR_EIGEN_TESTS_H

--- a/hector_stability_metrics/test/test_stability_measures.cpp
+++ b/hector_stability_metrics/test/test_stability_measures.cpp
@@ -12,84 +12,82 @@ using namespace Eigen;
 
 const double FLOATING_POINT_TOLLERANCE = 0.00001;
 
-TEST( StabilityMeasures, getLeastStableEdgeValue )
+TEST(StabilityMeasures, getLeastStableEdgeValue)
 {
   std::vector<double> edge_stabilities = { 1, 2, 3, -4 };
   size_t least_stable_index;
-  getLeastStableEdgeValue( edge_stabilities, least_stable_index );
+  getLeastStableEdgeValue(edge_stabilities, least_stable_index);
 
-  EXPECT_EQ( least_stable_index, 3 );
+  EXPECT_EQ(least_stable_index, 3);
 }
 
-TEST( StabilityMeasures, StaticStabilityMargin )
+TEST(StabilityMeasures, StaticStabilityMargin)
 {
-  Vector3d center_of_mass = Vector3d( 0.2, 0.7, 1 );
+  Vector3d center_of_mass = Vector3d(0.2, 0.7, 1);
 
-  Vector3dList sup_pol = { Vector3d( 0, 0, 0 ), Vector3d( 0, 2, 0 ), Vector3d( 1, 2, 0 ), Vector3d( 1, 0, 0 ) };
+  Vector3dList sup_pol = { Vector3d(0, 0, 0), Vector3d(0, 2, 0), Vector3d(1, 2, 0), Vector3d(1, 0, 0) };
   std::vector<double> edge_stabilities;
 
-  double stability_res = computeStaticStabilityMarginValue( sup_pol, edge_stabilities, center_of_mass );
+  double stability_res = computeStaticStabilityMarginValue(sup_pol, edge_stabilities, center_of_mass);
 
-  EXPECT_NEAR( edge_stabilities[0], 0.2, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[1], 1.3, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[2], 0.8, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[3], 0.7, FLOATING_POINT_TOLLERANCE );
+  EXPECT_NEAR(edge_stabilities[0], 0.2, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[1], 1.3, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[2], 0.8, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[3], 0.7, FLOATING_POINT_TOLLERANCE);
 
-  EXPECT_NEAR( stability_res, 0.2, FLOATING_POINT_TOLLERANCE );
+  EXPECT_NEAR(stability_res, 0.2, FLOATING_POINT_TOLLERANCE);
 
-  center_of_mass = Vector3d( -0.2, 0.7, 1 );
-  stability_res = computeStaticStabilityMarginValue( sup_pol, edge_stabilities, center_of_mass );
+  center_of_mass = Vector3d(-0.2, 0.7, 1);
+  stability_res = computeStaticStabilityMarginValue(sup_pol, edge_stabilities, center_of_mass);
 
-  EXPECT_NEAR( edge_stabilities[0], -0.2, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[1], 1.3, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[2], 1.2, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[3], 0.7, FLOATING_POINT_TOLLERANCE );
+  EXPECT_NEAR(edge_stabilities[0], -0.2, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[1], 1.3, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[2], 1.2, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[3], 0.7, FLOATING_POINT_TOLLERANCE);
 
-  EXPECT_NEAR( stability_res, -0.2, FLOATING_POINT_TOLLERANCE );
+  EXPECT_NEAR(stability_res, -0.2, FLOATING_POINT_TOLLERANCE);
 }
 
-TEST( StabilityMeasures, NormalizedEnergyStabilityMargin )
+TEST(StabilityMeasures, NormalizedEnergyStabilityMargin)
 {
-  Vector3d center_of_mass = Vector3d( 0.2, 0.7, 1 );
+  Vector3d center_of_mass = Vector3d(0.2, 0.7, 1);
 
-  Vector3dList sup_pol = { Vector3d( 0, 0, 0 ), Vector3d( 0, 2, 0 ), Vector3d( 1, 2, 0 ), Vector3d( 1, 0, 0 ) };
+  Vector3dList sup_pol = { Vector3d(0, 0, 0), Vector3d(0, 2, 0), Vector3d(1, 2, 0), Vector3d(1, 0, 0) };
   std::vector<double> edge_stabilities;
 
-  double stability_res = computeNormalizedEnergyStabilityMarginValue( sup_pol, edge_stabilities, center_of_mass );
+  double stability_res = computeNormalizedEnergyStabilityMarginValue(sup_pol, edge_stabilities, center_of_mass);
 
-  EXPECT_NEAR( edge_stabilities[0], 0, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[1], 0, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[2], 0, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[3], 0, FLOATING_POINT_TOLLERANCE );
+  EXPECT_NEAR(edge_stabilities[0], 0, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[1], 0, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[2], 0, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[3], 0, FLOATING_POINT_TOLLERANCE);
 
-  EXPECT_NEAR( stability_res, 0, FLOATING_POINT_TOLLERANCE );
+  EXPECT_NEAR(stability_res, 0, FLOATING_POINT_TOLLERANCE);
 
-  center_of_mass = Vector3d( -0.2, 0.7, 1 );
-  stability_res = computeNormalizedEnergyStabilityMarginValue( sup_pol, edge_stabilities, center_of_mass );
+  center_of_mass = Vector3d(-0.2, 0.7, 1);
+  stability_res = computeNormalizedEnergyStabilityMarginValue(sup_pol, edge_stabilities, center_of_mass);
 
-  EXPECT_NEAR( edge_stabilities[0], 0, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[1], 0, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[2], 0, FLOATING_POINT_TOLLERANCE );
-  EXPECT_NEAR( edge_stabilities[3], 0, FLOATING_POINT_TOLLERANCE );
+  EXPECT_NEAR(edge_stabilities[0], 0, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[1], 0, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[2], 0, FLOATING_POINT_TOLLERANCE);
+  EXPECT_NEAR(edge_stabilities[3], 0, FLOATING_POINT_TOLLERANCE);
 
-  EXPECT_NEAR( stability_res, 0, FLOATING_POINT_TOLLERANCE );
+  EXPECT_NEAR(stability_res, 0, FLOATING_POINT_TOLLERANCE);
 }
 
-TEST( StabilityMeasures, ForceAngleStabilityMeasureNonDifferentiable )
+TEST(StabilityMeasures, ForceAngleStabilityMeasureNonDifferentiable)
 {
-  Vector3d center_of_mass = Vector3d( 0.5, 0.5, 1 );
-  Vector3d external_force = Vector3d( 0, 0, -9.81 );
+  Vector3d center_of_mass = Vector3d(0.5, 0.5, 1);
+  Vector3d external_force = Vector3d(0, 0, -9.81);
 
-  Vector3dList sup_pol = { Vector3d( 0, 0, 0 ), Vector3d( 0, 1, 0 ), Vector3d( 1, 1, 0 ), Vector3d( 1, 0, 0 ) };
+  Vector3dList sup_pol = { Vector3d(0, 0, 0), Vector3d(0, 1, 0), Vector3d(1, 1, 0), Vector3d(1, 0, 0) };
   std::vector<double> edge_stabilities;
 
-  double stability = non_differentiable::computeForceAngleStabilityMeasureValue( sup_pol, edge_stabilities,
-                                                                                 center_of_mass,
-                                                                                 external_force );
+  double stability = non_differentiable::computeForceAngleStabilityMeasureValue(sup_pol, edge_stabilities, center_of_mass, external_force);
 }
 
-int main( int argc, char **argv )
+int main(int argc, char** argv)
 {
-  testing::InitGoogleTest( &argc, argv );
+  testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
- Change the typedef of MinimumFunction to std::function, which allows binding hyperparameters for soft

minimum functions with std::bind

- Add eigen3 as prefix for the Eigen include path to avoid compile errors