### PR TITLE
Fixed convex hull ordering for n=3

### DIFF
--- a/hector_stability_metrics/include/hector_stability_metrics/math/hull.h
+++ b/hector_stability_metrics/include/hector_stability_metrics/math/hull.h
@@ -39,9 +39,9 @@ inline void convexHull( const Container &points, Container &result )
 {
   size_t n = points.size();
   result.clear();
-  if ( n <= 3 )
+  if ( n <= 2 )
   {
-    result.reserve( 3 );
+    result.reserve( 2 );
     result.insert( result.begin(), points.begin(), points.end());
     return;
   }


### PR DESCRIPTION
For n=3, the returned point list is now guaranteed to be in clockwise ordering.